### PR TITLE
Fix the LibXML error appearing in the logs

### DIFF
--- a/init.php
+++ b/init.php
@@ -34,7 +34,7 @@ class MarkAsRead extends Plugin {
 	function hook_article_button($line) {
 		$myId = $line["id"];
 
-		return "<span style='cursor: pointer; vertical-align: bottom;' onclick='markasreadClicked(event,$myId);'><span style='min-width: 15px; min-height: 15px;' class='markasread'><img src='plugins/markasread/trans.png' class='tagsPic' width=15 height=15 /></span>".__('Mark as read')."</span>";
+		return "<span style='cursor: pointer; vertical-align: bottom;' onclick='markasreadClicked(event,$myId);'><span style='min-width: 15px; min-height: 15px;' class='markasread'><img src='plugins/markasread/trans.png' class='tagsPic' width='15' height='15' /></span>".__('Mark as read')."</span>";
 	}
 
 }


### PR DESCRIPTION
For a few months, the markasread plugin has stopped working due to some LibXML error during the initialisation of the plugin. The cause of this error was some missing single quotes around two properties.