### PR TITLE
Support both plugins and plugins.local locations for the CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Installation
 ------------
 
 ### Using git ###
-Just checkout the code into your plugins folder like this:
+Just checkout the code into your plugins.local folder like this:
 
 ```sh
 $ cd /path/to/your/tt-rss
-$ git clone git://github.com/Elv1zz/ttrss_plugin-markasread plugins/markasread
+$ git clone git://github.com/Elv1zz/ttrss_plugin-markasread plugins.local/markasread
 ```
 
 Then go to tt-rss preferences and enable the plugin.
@@ -21,8 +21,8 @@ Manually download, extract and copy the archive like this:
 $ cd /tmp
 $ wget https://github.com/Elv1zz/ttrss_plugin-markasread/archive/master.zip
 $ unzip master.zip
-$ mkdir /path/to/your/tt-rss/plugins/markasread
-$ cp ttrss_plugin-markasread-master/* /path/to/your/tt-rss/plugins/markasread
+$ mkdir /path/to/your/tt-rss/plugins.local/markasread
+$ cp ttrss_plugin-markasread-master/* /path/to/your/tt-rss/plugins.local/markasread
 ```
 
 Then go to tt-rss preferences and enable the plugin.
@@ -32,7 +32,7 @@ Update
 Just pull the most recent version from the server:
 
 ```sh
-$ cd /path/to/your/tt-rss/plugins/markasread
+$ cd /path/to/your/tt-rss/plugins.local/markasread
 $ git pull origin master
 ```
 

--- a/init.php
+++ b/init.php
@@ -28,13 +28,13 @@ class MarkAsRead extends Plugin {
 	}
 
 	function get_css() {
-		return file_get_contents(dirname(__FILE__) . "/markasread.css");
+		return str_replace("url(/markasread", "url(" . basename(dirname(__FILE__, 2)) . "/markasread", file_get_contents(dirname(__FILE__) . "/markasread.css"));
 	}
 
 	function hook_article_button($line) {
 		$myId = $line["id"];
 
-		return "<span style='cursor: pointer; vertical-align: bottom;' onclick='markasreadClicked(event,$myId);'><span style='min-width: 15px; min-height: 15px;' class='markasread'><img src='plugins/markasread/trans.png' class='tagsPic' width='15' height='15' /></span>".__('Mark as read')."</span>";
+		return "<span style='cursor: pointer; vertical-align: bottom;' onclick='markasreadClicked(event,$myId);'><span style='min-width: 15px; min-height: 15px;' class='markasread'><img src='" . basename(dirname(__FILE__, 2)) . "/markasread/trans.png' class='tagsPic' width='15' height='15' /></span>".__('Mark as read')."</span>";
 	}
 
 }

--- a/markasread.css
+++ b/markasread.css
@@ -1,10 +1,10 @@
 .markasread {
-	background-image: url(plugins/markasread/read.png);
+	background-image: url(/markasread/read.png);
 	background-repeat: no-repeat;
 }
 
 .Unread .markasread {
-	background-image: url(plugins/markasread/unread.png);
+	background-image: url(/markasread/unread.png);
 	background-repeat: no-repeat;
 }
 


### PR DESCRIPTION
The default location for user installed plugins in tt-rss seems to have moved from plugins to plugins.local quite some time ago. With this code modification, the markasread plugin can be installed in both locations (in fact, in any location) and still display correctly the images used in the CSS file.